### PR TITLE
Sw template

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build-sw": "node ./src/sw-build.js",
+    "clean-cra-sw": "rm -f build/precache-manifest.*.js && rm -f build/service-worker.js",
+    "build": "react-scripts build && npm run build-sw && npm run clean-cra-sw",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,9 @@ import ReactDOM from 'react-dom';
 
 import './index.css';
 import App from './app';
-import registerServiceWorker from './registerServiceWorker';
-
+import * as serviceWorker from './registerServiceWorker';
 
 ReactDOM.render((
   <App/>
 ), document.getElementById('root'));
-registerServiceWorker();
+serviceWorker.register();

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -1,12 +1,14 @@
-// In production, we register a service worker to serve assets from local cache.
+// This optional code is used to register a service worker.
+// register() is not called by default.
 
 // This lets the app load faster on subsequent visits in production, and gives
 // it offline capabilities. However, it also means that developers (and users)
-// will only see deployed updates on the "N+1" visit to a page, since previously
-// cached resources are updated in the background.
+// will only see deployed updates on subsequent visits to a page, after all the
+// existing tabs open on the page have been closed, since previously cached
+// resources are updated in the background.
 
-// To learn more about the benefits of this model, read https://goo.gl/KwvDNy.
-// This link also includes instructions on opting out of this behavior.
+// To learn more about the benefits of this model and instructions on how to
+// opt-in, read https://bit.ly/CRA-PWA
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
@@ -18,14 +20,14 @@ const isLocalhost = Boolean(
     )
 );
 
-export default function register() {
+export function register(config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(process.env.PUBLIC_URL, window.location);
+    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin
       // from what our page is served on. This might happen if a CDN is used to
-      // serve assets; see https://github.com/facebookincubator/create-react-app/issues/2374
+      // serve assets; see https://github.com/facebook/create-react-app/issues/2374
       return;
     }
 
@@ -33,44 +35,59 @@ export default function register() {
       //const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
       const swUrl = `${process.env.PUBLIC_URL}/sw.js`;
       if (isLocalhost) {
-        // This is running on localhost. Lets check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl);
+        // This is running on localhost. Let's check if a service worker still exists or not.
+        checkValidServiceWorker(swUrl, config);
 
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
         navigator.serviceWorker.ready.then(() => {
           console.log(
             'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit https://goo.gl/SC7cgQ'
+              'worker. To learn more, visit https://bit.ly/CRA-PWA'
           );
         });
       } else {
-        // Is not local host. Just register service worker
-        registerValidSW(swUrl);
+        // Is not localhost. Just register service worker
+        registerValidSW(swUrl, config);
       }
     });
   }
 }
 
-function registerValidSW(swUrl) {
+function registerValidSW(swUrl, config) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
+        if (installingWorker == null) {
+          return;
+        }
         installingWorker.onstatechange = () => {
           if (installingWorker.state === 'installed') {
             if (navigator.serviceWorker.controller) {
-              // At this point, the old content will have been purged and
-              // the fresh content will have been added to the cache.
-              // It's the perfect time to display a "New content is
-              // available; please refresh." message in your web app.
-              console.log('New content is available; please refresh.');
+              // At this point, the updated precached content has been fetched,
+              // but the previous service worker will still serve the older
+              // content until all client tabs are closed.
+              console.log(
+                'New content is available and will be used when all ' +
+                  'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
+              );
+
+              // Execute callback
+              if (config && config.onUpdate) {
+                config.onUpdate(registration);
+              }
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
               console.log('Content is cached for offline use.');
+
+              // Execute callback
+              if (config && config.onSuccess) {
+                config.onSuccess(registration);
+              }
             }
           }
         };
@@ -81,14 +98,15 @@ function registerValidSW(swUrl) {
     });
 }
 
-function checkValidServiceWorker(swUrl) {
+function checkValidServiceWorker(swUrl, config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
+      const contentType = response.headers.get('content-type');
       if (
         response.status === 404 ||
-        response.headers.get('content-type').indexOf('javascript') === -1
+        (contentType != null && contentType.indexOf('javascript') === -1)
       ) {
         // No service worker found. Probably a different app. Reload the page.
         navigator.serviceWorker.ready.then(registration => {
@@ -98,7 +116,7 @@ function checkValidServiceWorker(swUrl) {
         });
       } else {
         // Service worker found. Proceed as normal.
-        registerValidSW(swUrl);
+        registerValidSW(swUrl, config);
       }
     })
     .catch(() => {

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -30,8 +30,8 @@ export default function register() {
     }
 
     window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
-
+      //const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+      const swUrl = `${process.env.PUBLIC_URL}/sw.js`;
       if (isLocalhost) {
         // This is running on localhost. Lets check if a service worker still exists or not.
         checkValidServiceWorker(swUrl);

--- a/src/sw-build.js
+++ b/src/sw-build.js
@@ -1,0 +1,18 @@
+const workboxBuild = require('workbox-build');
+// NOTE: This should be run *AFTER* all your assets are built
+const buildSW = () => {
+  // This will return a Promise
+  return workboxBuild.injectManifest({
+    swSrc: 'src/sw-template.js', // this is your sw template file
+    swDest: 'build/sw.js', // this will be created in the build step
+    globDirectory: 'build',
+    globPatterns: [
+      '**\/*.{js,css,html,png}',
+    ]
+  }).then(({count, size, warnings}) => {
+    // Optionally, log any warnings and details.
+    warnings.forEach(console.warn);
+    console.log(`${count} files will be precached, totaling ${size} bytes.`);
+  });
+}
+buildSW();

--- a/src/sw-template.js
+++ b/src/sw-template.js
@@ -35,9 +35,9 @@ if ('function' === typeof importScripts) {
 
       /* 
          Custom cache rules - json 
-         Cache .geojson files.
-         Fetch garagesale.geojson from the network first if possible (as they are updated frequently).
-         Fallback to the cached garagesale.geojson if disconnected from the internet.
+         Cache .json files.
+         Fetch .json from the network first if possible (as they are updated frequently).
+         Fallback to the cached .json if disconnected from the internet.
        */
       workbox.routing.registerRoute(
         new RegExp('.*\.json'),

--- a/src/sw-template.js
+++ b/src/sw-template.js
@@ -1,0 +1,97 @@
+if ('function' === typeof importScripts) {
+    importScripts(
+      'https://storage.googleapis.com/workbox-cdn/releases/3.5.0/workbox-sw.js'
+    );
+    
+    /* global workbox */
+    if (workbox) {
+      
+      console.log('Workbox is loaded');
+  
+      /* injection point for manifest files.  */
+      workbox.precaching.precacheAndRoute([]);
+      
+      /* custom cache rules */
+      workbox.routing.registerNavigationRoute('/index.html', {
+        blacklist: [/^\/_/, /\/[^\/]+\.[^\/]+$/],
+      });
+      
+      /* Custom cache rules - app images 
+         Cache all image types.
+         Get images from the cache first.  
+         Fetch new images every 30 days so they are not stale - image update are NOT frequent. 
+       */
+      workbox.routing.registerRoute(
+        /\.(?:png|gif|jpg|jpeg|svg)$/,
+        workbox.strategies.cacheFirst({
+          cacheName: 'images',
+          plugins: [
+            new workbox.expiration.Plugin({
+              maxEntries: 60,
+              maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
+            })
+          ],
+        })
+      );
+
+      /* Custom cache rules - geojson 
+         Cache .geojson files.
+         Fetch garagesale.geojson from the network first if possible (as they are updated frequently).
+         Fallback to the cached garagesale.geojson if disconnected from the internet.
+       */
+      workbox.routing.registerRoute(
+        new RegExp('.*\.geojson'),
+        new workbox.strategies.NetworkFirst({
+          cacheName: 'geojson'
+        })
+      );
+      
+      // TODO: The below is a cache rule for Mapbox base map .png files.
+      // Update to cache Mapbox GL protobuffs instead
+      
+      /* Custom cache rules - map tiles 
+         Cache png map tiles from the external mapbox root url - for only successfull responses.
+       
+      workbox.routing.registerRoute(
+        new RegExp('^https://api.tiles.mapbox.com/v4/mapbox.streets/'),
+        new workbox.strategies.CacheFirst({
+          cacheName: 'map-tile-cache',
+          plugins: [
+            new workbox.cacheableResponse.Plugin({
+              statuses: [0, 200],
+            })
+          ]
+        })
+      );
+      */
+
+      // Cache the Google Fonts stylesheets with a stale-while-revalidate strategy.
+      workbox.routing.registerRoute(
+        /^https:\/\/fonts\.googleapis\.com/,
+        new workbox.strategies.StaleWhileRevalidate({
+          cacheName: 'google-fonts-stylesheets'
+        })
+      );
+
+      // Cache the underlying font files with a cache-first strategy for 1 year.
+      workbox.routing.registerRoute(
+        /^https:\/\/fonts\.gstatic\.com/,
+        new workbox.strategies.CacheFirst({
+          cacheName: 'google-fonts-webfonts',
+          plugins: [
+            new workbox.cacheableResponse.Plugin({
+              statuses: [0, 200]
+            }),
+            new workbox.expiration.Plugin({
+              maxAgeSeconds: 60 * 60 * 24 * 365,
+              maxEntries: 30
+            }),
+          ],
+        })
+      );
+
+  } else {
+      console.log('Workbox could not be loaded. No Offline support');
+    }
+  }
+  

--- a/src/sw-template.js
+++ b/src/sw-template.js
@@ -51,9 +51,9 @@ if ('function' === typeof importScripts) {
 
       /* Custom cache rules - map tiles 
          Cache png map tiles from the external mapbox root url - for only successfull responses.
-       
+      */ 
       workbox.routing.registerRoute(
-        new RegExp('^https://api.tiles.mapbox.com/v4/mapbox.streets/'),
+        new RegExp('^https://api.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,spatialdev.45mt0wo1,spatialdev.00lrg24b/'),
         new workbox.strategies.CacheFirst({
           cacheName: 'map-tile-cache',
           plugins: [
@@ -63,7 +63,7 @@ if ('function' === typeof importScripts) {
           ]
         })
       );
-      */
+      
 
       // Cache the Google Fonts stylesheets with a stale-while-revalidate strategy.
       workbox.routing.registerRoute(

--- a/src/sw-template.js
+++ b/src/sw-template.js
@@ -1,95 +1,93 @@
 if ('function' === typeof importScripts) {
-    importScripts(
-      'https://storage.googleapis.com/workbox-cdn/releases/3.5.0/workbox-sw.js'
+  importScripts(
+    'https://storage.googleapis.com/workbox-cdn/releases/3.5.0/workbox-sw.js'
+  );
+  
+  // global workbox
+  if (workbox) {
+    
+    // injection point for manifest files.
+    workbox.precaching.precacheAndRoute([]);
+    
+    // custom cache rules
+    workbox.routing.registerNavigationRoute('/index.html', {
+      blacklist: [/^\/_/, /\/[^\/]+\.[^\/]+$/],
+    });
+    
+    /* 
+      Custom cache rules - app images 
+      Cache all image types.
+      Get images from the cache first.  
+      Fetch new images every 30 days so they are not stale - image update are NOT frequent. 
+    */
+    workbox.routing.registerRoute(
+      /\.(?:png|gif|jpg|jpeg|svg)$/,
+      workbox.strategies.cacheFirst({
+        cacheName: 'sf-images',
+        plugins: [
+          new workbox.expiration.Plugin({
+            maxEntries: 60,
+            maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
+          })
+        ],
+      })
+    );
+
+    /* 
+      Custom cache rules - json 
+      Cache .json files.
+      Fetch .json from the network first if possible (as they are updated frequently).
+      Fallback to the cached .json if disconnected from the internet.
+    */
+    workbox.routing.registerRoute(
+      new RegExp('.*\.json'),
+      new workbox.strategies.NetworkFirst({
+        cacheName: 'sf-json'
+      })
+    );
+
+    /* 
+      Custom cache rules - map tiles 
+      Cache map tiles from the external mapbox root url - for only successfull responses.
+    */ 
+    workbox.routing.registerRoute(
+      new RegExp('^https://api.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,spatialdev.45mt0wo1,spatialdev.00lrg24b/'),
+      new workbox.strategies.CacheFirst({
+        cacheName: 'sf-map-tile-cache',
+        plugins: [
+          new workbox.cacheableResponse.Plugin({
+            statuses: [0, 200],
+          })
+        ]
+      })
     );
     
-    /* global workbox */
-    if (workbox) {
-  
-      /* injection point for manifest files.  */
-      workbox.precaching.precacheAndRoute([]);
-      
-      /* custom cache rules */
-      workbox.routing.registerNavigationRoute('/index.html', {
-        blacklist: [/^\/_/, /\/[^\/]+\.[^\/]+$/],
-      });
-      
-      /* 
-         Custom cache rules - app images 
-         Cache all image types.
-         Get images from the cache first.  
-         Fetch new images every 30 days so they are not stale - image update are NOT frequent. 
-       */
-      workbox.routing.registerRoute(
-        /\.(?:png|gif|jpg|jpeg|svg)$/,
-        workbox.strategies.cacheFirst({
-          cacheName: 'sf-images',
-          plugins: [
-            new workbox.expiration.Plugin({
-              maxEntries: 60,
-              maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
-            })
-          ],
-        })
-      );
+    // Cache the Google Fonts stylesheets with a stale-while-revalidate strategy.
+    workbox.routing.registerRoute(
+      /^https:\/\/fonts\.googleapis\.com/,
+      new workbox.strategies.StaleWhileRevalidate({
+        cacheName: 'google-fonts-stylesheets'
+      })
+    );
 
-      /* 
-         Custom cache rules - json 
-         Cache .json files.
-         Fetch .json from the network first if possible (as they are updated frequently).
-         Fallback to the cached .json if disconnected from the internet.
-       */
-      workbox.routing.registerRoute(
-        new RegExp('.*\.json'),
-        new workbox.strategies.NetworkFirst({
-          cacheName: 'sf-json'
-        })
-      );
-
-      /* 
-         Custom cache rules - map tiles 
-         Cache map tiles from the external mapbox root url - for only successfull responses.
-      */ 
-      workbox.routing.registerRoute(
-        new RegExp('^https://api.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,spatialdev.45mt0wo1,spatialdev.00lrg24b/'),
-        new workbox.strategies.CacheFirst({
-          cacheName: 'sf-map-tile-cache',
-          plugins: [
-            new workbox.cacheableResponse.Plugin({
-              statuses: [0, 200],
-            })
-          ]
-        })
-      );
-      
-
-      // Cache the Google Fonts stylesheets with a stale-while-revalidate strategy.
-      workbox.routing.registerRoute(
-        /^https:\/\/fonts\.googleapis\.com/,
-        new workbox.strategies.StaleWhileRevalidate({
-          cacheName: 'google-fonts-stylesheets'
-        })
-      );
-
-      // Cache the underlying font files with a cache-first strategy for 1 year.
-      workbox.routing.registerRoute(
-        /^https:\/\/fonts\.gstatic\.com/,
-        new workbox.strategies.CacheFirst({
-          cacheName: 'google-fonts-webfonts',
-          plugins: [
-            new workbox.cacheableResponse.Plugin({
-              statuses: [0, 200]
-            }),
-            new workbox.expiration.Plugin({
-              maxAgeSeconds: 60 * 60 * 24 * 365,
-              maxEntries: 30
-            }),
-          ],
-        })
-      );
-
-  } else {
-      console.log('Workbox could not be loaded. No Offline support');
-    }
+    // Cache the underlying font files with a cache-first strategy for 1 year.
+    workbox.routing.registerRoute(
+      /^https:\/\/fonts\.gstatic\.com/,
+      new workbox.strategies.CacheFirst({
+        cacheName: 'google-fonts-webfonts',
+        plugins: [
+          new workbox.cacheableResponse.Plugin({
+            statuses: [0, 200]
+          }),
+          new workbox.expiration.Plugin({
+            maxAgeSeconds: 60 * 60 * 24 * 365,
+            maxEntries: 30
+          }),
+        ],
+      })
+    );
+} else {
+    console.log('Workbox could not be loaded. No Offline support');
   }
+}
   

--- a/src/sw-template.js
+++ b/src/sw-template.js
@@ -16,7 +16,8 @@ if ('function' === typeof importScripts) {
         blacklist: [/^\/_/, /\/[^\/]+\.[^\/]+$/],
       });
       
-      /* Custom cache rules - app images 
+      /* 
+         Custom cache rules - app images 
          Cache all image types.
          Get images from the cache first.  
          Fetch new images every 30 days so they are not stale - image update are NOT frequent. 
@@ -34,7 +35,8 @@ if ('function' === typeof importScripts) {
         })
       );
 
-      /* Custom cache rules - json 
+      /* 
+         Custom cache rules - json 
          Cache .geojson files.
          Fetch garagesale.geojson from the network first if possible (as they are updated frequently).
          Fallback to the cached garagesale.geojson if disconnected from the internet.
@@ -46,16 +48,14 @@ if ('function' === typeof importScripts) {
         })
       );
 
-      // TODO: The below is a cache rule for Mapbox base map .png files.
-      // Update to cache Mapbox GL protobuffs instead
-
-      /* Custom cache rules - map tiles 
-         Cache png map tiles from the external mapbox root url - for only successfull responses.
+      /* 
+         Custom cache rules - map tiles 
+         Cache map tiles from the external mapbox root url - for only successfull responses.
       */ 
       workbox.routing.registerRoute(
         new RegExp('^https://api.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,spatialdev.45mt0wo1,spatialdev.00lrg24b/'),
         new workbox.strategies.CacheFirst({
-          cacheName: 'map-tile-cache',
+          cacheName: 'sf-map-tile-cache',
           plugins: [
             new workbox.cacheableResponse.Plugin({
               statuses: [0, 200],

--- a/src/sw-template.js
+++ b/src/sw-template.js
@@ -6,7 +6,7 @@ if ('function' === typeof importScripts) {
     /* global workbox */
     if (workbox) {
       
-      console.log('Workbox is loaded');
+      console.log('Workbox for SFF is loaded');
   
       /* injection point for manifest files.  */
       workbox.precaching.precacheAndRoute([]);
@@ -24,7 +24,7 @@ if ('function' === typeof importScripts) {
       workbox.routing.registerRoute(
         /\.(?:png|gif|jpg|jpeg|svg)$/,
         workbox.strategies.cacheFirst({
-          cacheName: 'images',
+          cacheName: 'sf-images',
           plugins: [
             new workbox.expiration.Plugin({
               maxEntries: 60,
@@ -34,21 +34,21 @@ if ('function' === typeof importScripts) {
         })
       );
 
-      /* Custom cache rules - geojson 
+      /* Custom cache rules - json 
          Cache .geojson files.
          Fetch garagesale.geojson from the network first if possible (as they are updated frequently).
          Fallback to the cached garagesale.geojson if disconnected from the internet.
        */
       workbox.routing.registerRoute(
-        new RegExp('.*\.geojson'),
+        new RegExp('.*\.json'),
         new workbox.strategies.NetworkFirst({
-          cacheName: 'geojson'
+          cacheName: 'sf-json'
         })
       );
-      
+
       // TODO: The below is a cache rule for Mapbox base map .png files.
       // Update to cache Mapbox GL protobuffs instead
-      
+
       /* Custom cache rules - map tiles 
          Cache png map tiles from the external mapbox root url - for only successfull responses.
        

--- a/src/sw-template.js
+++ b/src/sw-template.js
@@ -5,8 +5,6 @@ if ('function' === typeof importScripts) {
     
     /* global workbox */
     if (workbox) {
-      
-      console.log('Workbox for SFF is loaded');
   
       /* injection point for manifest files.  */
       workbox.precaching.precacheAndRoute([]);

--- a/src/sw-template.js
+++ b/src/sw-template.js
@@ -86,7 +86,7 @@ if ('function' === typeof importScripts) {
         ],
       })
     );
-} else {
+  } else {
     console.log('Workbox could not be loaded. No Offline support');
   }
 }


### PR DESCRIPTION
### Description:

This introduces basic scaffolding for using a service worker to do the following:
* adds index.html, .css, and .js files to Cache Storage
* adds all image files (.png, .jpg, .jpeg, .svg) files to Cache Storage
* adds .json files to Cache Storage
* adds Mapbox tiles to Cache Storage.

This allows support for offline use of SeafoodFest app.

In general, the approach is the following:
* create a service worker build file
* create a service worker template file - allowing developers to use Workbox caching rules
* update the create-react-app build by simply introducing use of the above to build the Service Worker.

The details of how the Service Worker caching was added is represented in this wiki entry here: 
https://github.com/spatialdev/react-seafood/wiki/Caching-with-Service-Worker

### UI images:

There are no changes to the UI.

### Unit Test Approach:

Because this is simply app scaffolding there are no automated unit tests.

### Test Results:

See above - this is app scaffolding and no unit tests are created.

Describe other (non-unit) test results here.

The service worker integration can be manually tested in the following ways:
* Use create-react-app to build.
* Deploy the app to a web server (or s3) that uses an SSL cert and supports HTTPS.
* Run the app.
* Go to Chrome Dev Tools > Application > Service and see the service worker is registered.  Also confirm that you see the various assets in Cache Storage.  Alternatively, run a Lighthouse audit and see in the PWA section that the service worker is registered.
* Use the app and let the browser cache assets.
* Take the app offline and confirm that the app has offline support (Mapbox map tiles, images, etc.)