### PR TITLE
Add Arts & Crafts Vendors to left menu

### DIFF
--- a/src/components/leftDrawer/leftDrawer.js
+++ b/src/components/leftDrawer/leftDrawer.js
@@ -166,7 +166,7 @@ class LeftDrawer extends Component {
             setTabValue({index: 2, name: "A/C"});
             selectLeftMenuItem("A/C");
           }}>
-            <ListItemText disableTypography={true} classes={{root: 'list-item-text'}} primary="Arts and Crafts"/>
+            <ListItemText disableTypography={true} classes={{root: 'list-item-text'}} primary="Arts & Crafts Vendors"/>
           </ListItem>
           {menuItems.map((item, index) => {
             return (

--- a/src/components/leftDrawer/leftDrawer.js
+++ b/src/components/leftDrawer/leftDrawer.js
@@ -159,6 +159,15 @@ class LeftDrawer extends Component {
           }}>
             <ListItemText disableTypography={true} classes={{root: 'list-item-text'}} primary="Food Vendors"/>
           </ListItem>
+          <ListItem className="list-item-wrapper" button onClick={() => {
+            // Close the right & left menu
+            toggleRightDrawer(true);
+            toggleLeftDrawer(false);
+            setTabValue({index: 2, name: "A/C"});
+            selectLeftMenuItem("A/C");
+          }}>
+            <ListItemText disableTypography={true} classes={{root: 'list-item-text'}} primary="Arts and Crafts"/>
+          </ListItem>
           {menuItems.map((item, index) => {
             return (
               <div key={item.properties.id}>

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -12,8 +12,9 @@ import {
   FIND_MY_LOCATION_SELECT,
   FIND_MY_LOCATION_SUCCESS
 } from "../../redux/constants";
+import { config } from '../../config';
 
-mapboxgl.accessToken = 'pk.eyJ1Ijoic3BhdGlhbGRldiIsImEiOiJjamxuN2kydGIxZzhsM3BwbmNrYmhpaWRkIn0.51uF3UCh8Vpb2M3Y-glu2g';
+mapboxgl.accessToken = config.map.accessToken;
 
 const styles = theme => ({
   map: {
@@ -47,20 +48,13 @@ class Map extends Component {
     trackUserLocation: true
   });
 
-  bounds = [
-    //southwest
-    [-122.38885402679443, 47.66567637286265],
-    //northeast
-    [-122.37951993942261, 47.6712685277693]
-  ];
 
   componentDidMount() {
 
     const map = new mapboxgl.Map({
       container: this.mapContainer,
-      style: 'mapbox://styles/spatialdev/cjxy5fl8q0j5v1co88xg7dhtm',
-      center: [-122.38473415374757, 47.668667600018416],
-      // maxBounds: this.bounds,
+      style: config.map.style,
+      center: config.map.centroid,
       zoom: 18
     });
 

--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,18 @@ const config = {
         }
       }
     }
+  },
+  // Mapbox GL
+  map: {
+    style: 'mapbox://styles/spatialdev/cjxy5fl8q0j5v1co88xg7dhtm',
+    accessToken: "pk.eyJ1Ijoic3BhdGlhbGRldiIsImEiOiJjamxuN2kydGIxZzhsM3BwbmNrYmhpaWRkIn0.51uF3UCh8Vpb2M3Y-glu2g",
+    centroid: [-122.38473415374757, 47.668667600018416],
+    bounds: [
+      //southwest
+      [-122.38885402679443, 47.66567637286265],
+      //northeast
+      [-122.37951993942261, 47.6712685277693]
+    ]
   }
 }
 


### PR DESCRIPTION
### Description:

I added a "Arts & Crafts Vendors" List item on the left navigation. On select, the right panel will open with the tab value of 2 which corresponds to the arts and crafts list 
Fixes #67. 

I also added the mapbox gl Map options to a configuration

### UI images:
Clicking this...
<img width="536" alt="Screen Shot 2019-07-11 at 1 10 25 PM" src="https://user-images.githubusercontent.com/1947857/61081994-650d9680-a3dd-11e9-8505-e3a25af9665a.png">

Should open up this!
<img width="531" alt="Screen Shot 2019-07-11 at 1 11 14 PM" src="https://user-images.githubusercontent.com/1947857/61082012-6939b400-a3dd-11e9-878a-579d139c117f.png">

### Unit Test Approach:

No tests

### Test Results:
- [ ] Did you run `npm test` and did the results pass?
- [ ] Did you add unit tests that cover your changes?

Describe other (non-unit) test results here.
