### PR TITLE
Update beer garden specific ticket sales icons and name

### DIFF
--- a/src/components/bottomDrawer/bottomDrawer.js
+++ b/src/components/bottomDrawer/bottomDrawer.js
@@ -66,7 +66,8 @@ class BottomSheet extends Component {
     "Seafood Shack": imgIconCrab,
     "SeafoodFest Info": imgIconInfo,
     "Lutefisk Contest": imgIconContest,
-    "Token sales": imgIconTickets,
+    "Token Sales": imgIconTickets,
+    "Beer + Cocktail Garden Token Sales": imgIconTickets
   }
 
   games = [

--- a/src/data/polygons_2019.json
+++ b/src/data/polygons_2019.json
@@ -3573,7 +3573,7 @@
             "id": 9988,
             "rotate": null,
             "left_panel": null,
-            "name": "Token Sales",
+            "name": "Beer + Cocktail Garden Token Sales",
             "type": "Sponsor",
             "description": "Beer + Cocktail Garden Token Sales",
             "details": "info"
@@ -3609,7 +3609,7 @@
             "id": 9989,
             "rotate": null,
             "left_panel": null,
-            "name": "Token Sales",
+            "name": "Beer + Cocktail Garden Token Sales",
             "type": "Sponsor",
             "description": "Beer + Cocktail Garden Token Sales",
             "details": "info"


### PR DESCRIPTION
### Description:

This updates the beer garden ticket sales points name from `Token Sales` to `Beer + Cocktail Garden Token Sales`.  This insures the ticket sales icon renders on the bottom panel on select.

We previously changed the descriptions to `Beer + Cocktail Garden Token Sales`, however the bottom panel renders the `name` property.

### UI images:

Before....
<img width="512" alt="Screen Shot 2019-07-11 at 7 20 05 PM" src="https://user-images.githubusercontent.com/1947857/61097704-2e517380-a411-11e9-8648-42f1e623a391.png">

And After
<img width="516" alt="Screen Shot 2019-07-11 at 7 20 16 PM" src="https://user-images.githubusercontent.com/1947857/61097716-36a9ae80-a411-11e9-8127-8d4912e4fc49.png">


### Unit Test Approach:
 
Describe unit tests being added with that PR.

### Test Results:
- [ x ] Did you run `npm test` and did the results pass?
- [ x ] Did you add unit tests that cover your changes?

Describe other (non-unit) test results here.
