### PR TITLE
Use official GA tracking id

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,7 @@ const config = {
   // Google Analytics
   ga: {
     // Global GA identifier
-    id: 'UA-XXXXXXXX-1',
+    id: 'UA-80485263-1',
     // Event Category constants
     event: {
       // Vendor click events


### PR DESCRIPTION
### Description:

I originally excluded the official GA id from the repo to prevent from analytics being recorded for development, however, we can set a filter on Google Analysts to only show metrics from a specific hostname (map.seafoodfest.org).

The long term fix is to use node ENV variables to add the prod on master deploy.

### UI images:

Please add images for any changes to the UI.

### Unit Test Approach:

Describe unit tests being added with that PR.

### Test Results:
- [ ] Did you run `npm test` and did the results pass?
- [ ] Did you add unit tests that cover your changes?

Describe other (non-unit) test results here.
