### PR TITLE
fixes main stage tabs by shorting tab width

### DIFF
--- a/src/components/bottomDrawer/stage/stage.js
+++ b/src/components/bottomDrawer/stage/stage.js
@@ -28,10 +28,11 @@ class Stage extends Component {
               indicatorColor="primary"
               textColor="primary"
               scrollButtons="on"
+              variant="scrollable"
               scrollable>
-          <Tab label="Fri July 12th" />
-          <Tab label="Sat - July 13th" />
-          <Tab label="Sun - July 14th" />
+          <Tab label="Friday July 12th" />
+          <Tab label="Saturday - July 13th" />
+          <Tab label="Sunday - July 14th" />
         </Tabs>
 
         {value === 0 && <TabContainer>

--- a/src/components/bottomDrawer/stage/stage.js
+++ b/src/components/bottomDrawer/stage/stage.js
@@ -29,9 +29,9 @@ class Stage extends Component {
               textColor="primary"
               scrollButtons="on"
               scrollable>
-          <Tab label="Friday July 12th" />
-          <Tab label="Saturday - July 13th" />
-          <Tab label="Sunday - July 14th" />
+          <Tab label="Fri July 12th" />
+          <Tab label="Sat - July 13th" />
+          <Tab label="Sun - July 14th" />
         </Tabs>
 
         {value === 0 && <TabContainer>


### PR DESCRIPTION
### Description:

Todd reported ... "I cannot access Sunday Main Stage schedul"

See image:

![before](https://user-images.githubusercontent.com/1209057/61156183-9eaad400-a4a7-11e9-8b30-848c1e04acb3.png)

### UI images:

I simply changed such that the tabs have a smaller width - via using Fri, Sat, Sun instead of Friday Saturday, Sunday

See screenshot below:
![after](https://user-images.githubusercontent.com/1209057/61156237-b6825800-a4a7-11e9-92ed-b6eda8f2129d.png)

### Unit Test Approach:

UI changes no unit tests

### Test Results:

see above
