### PR TITLE
Switch to awscliv2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ script:
 - npm test
 - npm run build
 before_deploy:
-  - 'curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"'
-  - 'unzip awscli-bundle.zip'
-  - './awscli-bundle/install -b ~/bin/aws'
+  - 'curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"'
+  - 'unzip awscliv2.zip'
+  - 'sudo ./aws/install -b ~/bin/aws'
   - 'export PATH=~/bin:$PATH'
 deploy:
     - provider: s3


### PR DESCRIPTION
### Description:

In 2021, AWS CLI moved away from supporting Python 2.7 in the AWS CLI v1 install. The Travis virtual machine currently defaults to Python 2.7, preventing the install from being successful, and blocking deployment to S3. 

This PR switches to AWS CLI v2, which doesn't have the same restriction. 

